### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,8 +818,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/iOSUIComponents](https://starchart.cc/muhittincamdali/iOSUIComponents.svg)](https://github.com/muhittincamdali/iOSUIComponents/stargazers)
-
 ## 🏆 Achievements
 
 <div align="center">


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.